### PR TITLE
removed unused useState from SpellCard

### DIFF
--- a/src/components/SpellCard.js
+++ b/src/components/SpellCard.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 function SpellCard(spell) {
     return (


### PR DESCRIPTION
During deploy react-scripts build output a warning about an unusedvar. working out how to recreate it.